### PR TITLE
Add option to press enter to exit

### DIFF
--- a/PlexCleaner.py
+++ b/PlexCleaner.py
@@ -220,33 +220,6 @@ def dumpSettings(output):
     #Remove old settings
     if 'End Preferences' in Settings['ShowPreferences']:
         Settings['ShowPreferences'].pop('End Preferences')
-    # settings = OrderedDict([
-    #     ('Host', Settings['Host']),
-    #     ('Port', Settings['Port']),
-    #     ('SectionList', Settings['SectionList']),
-    #     ('IgnoreSections', Settings['IgnoreSections']),
-    #     ('LogFile', Settings['LogFile']),
-    #     ('trigger_rescan', Settings['trigger_rescan']),
-    #     ('Token', Settings['Token']),
-    #     ('Username', Settings['Username']),
-    #     ('Password', Settings['Password']),
-    #     ('RemoteMount', Settings['RemoteMount']),
-    #     ('LocalMount', Settings['LocalMount']),
-    #     ('plex_delete', Settings['plex_delete']),
-    #     ('similar_files', similar_files),
-    #     ('cleanup_movie_folders', cleanup_movie_folders),
-    #     ('minimum_folder_size', minimum_folder_size),
-    #     ('default_episodes', Settings['default_epiosdes']),
-    #     ('default_minDays', default_minDays),
-    #     ('default_maxDays', default_maxDays),
-    #     ('default_action', Settings['default_action']),
-    #     ('default_watched', default_watched),
-    #     ('default_location', default_location),
-    #     ('default_onDeck', default_onDeck),
-    #     ('ShowPreferences', OrderedDict(sorted(ShowPreferences.items()))),
-    #     ('MoviePreferences', OrderedDict(sorted(MoviePreferences.items()))),
-    #     ('Version', CONFIG_VERSION)
-    # ])
     Settings['ShowPreferences'] = OrderedDict(sorted(Settings['ShowPreferences'].items()))
     Settings['MoviePreferences'] = OrderedDict(sorted(Settings['MoviePreferences'].items()))
     Settings['Version'] = CONFIG_VERSION

--- a/PlexCleaner.py
+++ b/PlexCleaner.py
@@ -744,6 +744,8 @@ if Settings['Shared'] and Settings['Token']:
     accessToken = getAccessToken(Settings['Token'])
     if accessToken:
         Settings['Token'] = accessToken
+        if test:
+            log("Access Token: " + Settings['Token'], True)
     else:
         log("Access Token not found or not a shared account")
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@ A Script to clean up space on your Plex Media Server!
 
 Automatically delete watched episodes or movies. Lots of customizable options.
 
-There are many options that can be edited in the script. To create a config file run the script with the option --dump [Path to Config file].
+To begin make a copy of Cleaner.conf.default and rename it as Cleaner.conf. You can then make edits to the Cleaner.conf file with your own settings. Descriptions of the settings are in the PlexCleaner.py script.
+
+Alternatively you can create a config file by running the script with the option --dump [Path to Config file].
 
     python PlexCleaner.py --dump "/path/to/config/file"
 
-PlexCleaner will then create a config file at the path specified with example values. You can then make edits to the config file based on your preferences.
-The formatting is very specific for the config file, if you have difficulty editing it, you can edit the default values in the script and then run the --dump argument to create a properly formatted config file.
+PlexCleaner will then create a config file at the path specified with example values. You can then make edits to the config file based on your preferences. The formatting is very specific for the config file, if you have difficulty editing it, you can edit the default values in the script and then run the --dump argument to create a properly formatted config file.
 
-By default plex will check in the users home directory for a .plexcleaner file then in the current directory for a .plexcleaner or Cleaner.conf file. If you stored the config file in another location you will need to load the config file using the --config argument.
+By default plex will check in the users home directory for a .plexcleaner file, then in the current directory for a .plexcleaner or Cleaner.conf file. If you stored the config file in another location you will need to load the config file using the --config argument.
 To do so you would run PlexCleaner as:
 
     python PlexCleaner.py --config "/path/to/config/file"


### PR DESCRIPTION
This adds an option to the configuration file to ask for confirmation before exiting.  It defaults to false.  If True it will require the user to press the enter key before the program will exit, allowing the user to view the summary results on screen before the window closes if run outside the command prompt.