### PR TITLE
Add option to press enter to exit

### DIFF
--- a/Cleaner.conf.default
+++ b/Cleaner.conf.default
@@ -10,6 +10,7 @@
   "Password": "",
   "RemoteMount": "",
   "LocalMount": "",
+  "PressEnterToExit": true,
   "plex_delete": false,
   "similar_files": true,
   "cleanup_movie_folders": false,

--- a/Cleaner.conf.default
+++ b/Cleaner.conf.default
@@ -10,7 +10,7 @@
   "Password": "",
   "RemoteMount": "",
   "LocalMount": "",
-  "PressEnterToExit": true,
+  "PressEnterToExit": false,
   "plex_delete": false,
   "similar_files": true,
   "cleanup_movie_folders": false,

--- a/PlexCleaner.py
+++ b/PlexCleaner.py
@@ -40,6 +40,8 @@ RemoteMount = ""  # Path on the remote server to the media files
 LocalMount = ""  # Path on the local computer to the media files
 ##########################################################################
 
+PressEnterToExit = False  # PressEnterToExit will pause the program at the summary screen and await a press of the enter key before exiting
+
 ## DEFAULT SETTINGS PER SHOW #############################################
 # These are the default actions that are applied to each show.
 #
@@ -274,6 +276,7 @@ def LoadSettings(opts):
     s['DeviceName'] = opts.get('DeviceName', DeviceName)
     s['RemoteMount'] = opts.get('RemoteMount', RemoteMount)
     s['LocalMount'] = opts.get('LocalMount', LocalMount)
+    s['PressEnterToExit'] = opts.get('PressEnterToExit', PressEnterToExit)
     s['plex_delete'] = opts.get('plex_delete', plex_delete)
     s['similar_files'] = opts.get('similar_files', similar_files)
     s['cleanup_movie_folders'] = opts.get('cleanup_movie_folders', cleanup_movie_folders)
@@ -820,6 +823,9 @@ if not Settings['LogFile'] == "":
     logging.basicConfig(filename=Settings['LogFile'], filemode='w', level=logging.DEBUG)
     logging.captureWarnings(True)
 
+if not Settings['PressEnterToExit'] == "":
+    PressEnterToExit = Settings['PressEnterToExit']	
+
 if Token == "":
     if not Settings['Username'] == "":
         Settings['Token'] = getToken(Settings['Username'], Settings['Password'])
@@ -934,3 +940,8 @@ log("  Rescanned Sections    " + ', '.join(str(x) for x in RescannedSections))
 log("")
 log("----------------------------------------------------------------------------")
 log("----------------------------------------------------------------------------")
+if PressEnterToExit:
+    try:
+        input("Press Enter to Exit...")
+    except Exception:
+        pass


### PR DESCRIPTION
This adds an option to the configuration file to ask for confirmation before exiting. It defaults to false. If True it will require the user to press the enter key before the program will exit, allowing the user to view the summary results on screen before the window closes if run outside the command prompt.