### PR TITLE
Added feature: Empty watched files

### DIFF
--- a/PlexCleaner.py
+++ b/PlexCleaner.py
@@ -422,6 +422,16 @@ def performAction(file, action, media_id=0, location=""):
                 os.unlink(f)
         MoveCount += 1
         return True
+    elif action.startswith('e'):
+        for deleteFile in filelist:
+            try:
+                open(deleteFile, 'w').close()
+                log("**[EMPTIED] " + deleteFile)
+            except Exception as e:
+                log("Error emptying file: %s" % e, True)
+                continue
+        DeleteCount += 1
+        return True
     elif action.startswith('d'):
         for deleteFile in filelist:
             try:


### PR DESCRIPTION
Hello,

thanks for writing PlexCleaner!
I want to keep track of episodes I have watched already, but I do want to free the space of the recordings.
For this, I have added this patch to Plex-Cleaner.

A new action 'empty' is added to PlexCleaner. It does the same as 'delete' but instead of deleting the file, it only removes its content.

This way, the file is still visible in Plex and on my drive, but it needs no space.

Regards,
Hendrik