### PR TITLE
Change "True" to lowercase in default config

### DIFF
--- a/Cleaner.conf.default
+++ b/Cleaner.conf.default
@@ -1,5 +1,5 @@
 {
-  "test": True,
+  "test": true,
   "Host": "127.0.0.1",
   "Port": "32400",
   "SectionList": [],


### PR DESCRIPTION
Uppercase "T" was giving me "No JSON object could be decoded"